### PR TITLE
Removed deprecated pyfits and replaced with astropy

### DIFF
--- a/FF_bin_suite.py
+++ b/FF_bin_suite.py
@@ -27,7 +27,7 @@ import subprocess
 import platform
 
 import numpy as np
-import pyfits
+import astropy.io.fits as pyfits
 from PIL import Image as img
 from PIL import ImageFont
 from PIL import ImageDraw

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To run or build from source you will need (take notice of the used versions):
 - scipy 0.14.0 (this version is strongly recommended, I also tested on 0.15.0 but it requires some tinkering with DLLs on Windows)
 - numpy 1.8.2
 - PIL (Python Image Library) - Pillow-2.5.1
-- pyfits
+- astropy
 - imageio
 
 To make a Windows exe:
@@ -48,7 +48,7 @@ And install the requirements:
 ```
 conda install -y numpy scipy
 conda install -y -c anaconda wxpython 
-conda install -y -c sherpa pyfits
+conda install -y astropy
 conda install -y -c conda-forge pillow imageio
 ```
 


### PR DESCRIPTION
Pyfits is deprecated and has been replaced by functionality in astropy (see note on the pyfits github page). To cater for this i updated FF_bin_suite.py and the README file appropriately.
Tested on my own data without issues. 