### PR TITLE
Fixes to bugs reported by Paul Roggemans

### DIFF
--- a/CMN_binViewer.py
+++ b/CMN_binViewer.py
@@ -70,7 +70,7 @@ from module_confirmationClass import Confirmation
 from module_highlightMeteorPath import highlightMeteorPath
 from module_CAMS2CMN import convert_rmsftp_to_cams
 
-version = 3.21 
+version = 3.22 
 
 # set to true to disable the video radiobutton
 disable_UI_video = False
@@ -3162,19 +3162,24 @@ class BinViewer(Frame):
                 print('unable to write new FTPDetect file')
 
             # write filtered UFO-compatible R91 csv file 
-            self.timestamp_label.configure(text = "writing UFO file...")
-            _, ufoFile=os.path.split(self.dir_path)
-            ufoFile = ufoFile + '.csv'
-            with open(os.path.join(self.dir_path, ufoFile),'r') as uf:
-                ufoData = uf.readlines()
-
-            newufoData = self.updateUFOData(FTPdetectinfoExport, ufoData)
+            self.timestamp_label.configure(text = "Updating UFO file...")
             try:
-                with open(os.path.join(self.ConfirmationInstance.confirmationDirectory, ufoFile), 'w') as newUfoFile:
-                    for line in newufoData:
-                        newUfoFile.write(line)
+                ufoFile = glob.glob(os.path.join(self.dir_path, '*.csv'))[0]
+
+                #_, ufoFile=os.path.split(self.dir_path)
+                # ufoFile = ufoFile + '.csv'
+                with open(os.path.join(self.dir_path, ufoFile),'r') as uf:
+                    ufoData = uf.readlines()
+
+                newufoData = self.updateUFOData(FTPdetectinfoExport, ufoData)
+                try:
+                    with open(os.path.join(self.ConfirmationInstance.confirmationDirectory, ufoFile), 'w') as newUfoFile:
+                        for line in newufoData:
+                            newUfoFile.write(line)
+                except Exception:
+                    print('unable to write CSV file')
             except Exception:
-                print('unable to write CSV file')
+                print('CSV file not present')
 
 
             # create CAMS compatible ftpdetect file if needed

--- a/CMN_binViewer.py
+++ b/CMN_binViewer.py
@@ -815,6 +815,7 @@ class BinViewer(Frame):
 
     def updateUFOData(self, ftpdata, ufoData):
 
+
         newufoData = []
         tstamps = []
         for li in range(len(ufoData)):
@@ -3143,7 +3144,7 @@ class BinViewer(Frame):
                 if ('FTPdetectinfo' in dir_file) and file_ext == '.txt' and not ('_original' in file_name):
                     copy2(os.path.join(self.dir_path, dir_file), os.path.join(self.ConfirmationInstance.confirmationDirectory, "".join(dir_file.split('.')[:-1]) + '_pre-confirmation.txt'))
                     continue
-                elif file_ext in ('.txt', '.inf', '.rpt', '.log', '.cal', '.hmm', '.json', '.csv') or dir_file == '.config':
+                elif file_ext in ('.txt', '.inf', '.rpt', '.log', '.cal', '.hmm', '.json','.csv') or dir_file == '.config':
                     copy2(os.path.join(self.dir_path, dir_file), os.path.join(self.ConfirmationInstance.confirmationDirectory, dir_file))
 
                 # get the CAMS CAL file name, if present, and from it the CAMS code
@@ -3173,9 +3174,12 @@ class BinViewer(Frame):
 
                 newufoData = self.updateUFOData(FTPdetectinfoExport, ufoData)
                 try:
-                    with open(os.path.join(self.ConfirmationInstance.confirmationDirectory, ufoFile), 'w') as newUfoFile:
+                    _, ufof = os.path.split(ufoFile)
+                    fnam = os.path.join(self.ConfirmationInstance.confirmationDirectory, ufof)
+                    with open(fnam, 'w') as newUfoFile:
                         for line in newufoData:
                             newUfoFile.write(line)
+
                 except Exception:
                     print('unable to write CSV file')
             except Exception:

--- a/CMN_binViewer_setup.iss
+++ b/CMN_binViewer_setup.iss
@@ -7,7 +7,7 @@
 
 [Setup]
 AppName=CMN_binViewer
-AppVersion=3.2
+AppVersion=3.22
 AppPublisher=Croatian Meteor Network
 AppPublisherURL=http://cmn.rgn.hr/
 DefaultDirName={commonpf64}\CMN_binViewer

--- a/CMN_binViewer_setup_win32.iss
+++ b/CMN_binViewer_setup_win32.iss
@@ -7,7 +7,7 @@
 
 [Setup]
 AppName=CMN_binViewer
-AppVersion=3.2
+AppVersion=3.22
 AppPublisher=Croatian Meteor Network
 AppPublisherURL=http://cmn.rgn.hr/
 DefaultDirName={commonpf}\CMN_binViewer

--- a/config.ini
+++ b/config.ini
@@ -4,4 +4,6 @@
 orientation = 0 # 0 horizontal, 1 vertical
 fps = 25
 image_resize_factor = 2
-
+external_video = 0
+edge_marker = 1
+external_guidelines = 1


### PR DESCRIPTION
Programme crashed if folder name did not match UFO CSV file name. (for example if data was extracted from the bz2 file rather than copied from the Pi directly).
Updated UFO CSV file created in wrong folder.