### PR TITLE
Use path to config file

### DIFF
--- a/CMN_binViewer.py
+++ b/CMN_binViewer.py
@@ -78,7 +78,7 @@ disable_UI_video = False
 global_bg = "Black"
 global_fg = "Gray"
 
-config_file = 'config.ini'
+config_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'config.ini')
 
 log_directory = 'CMN_binViewer_logs'
 


### PR DESCRIPTION
This will find the config.ini inside the directory where CMN_binviewer.py, even if CMN_binviewer is run from another directory.

The previous construction would create a config.ini in the working directory, which is quite surprising, specially when you run from a directory where an existing config.ini is overwritten.