### PR TITLE
Removing config file from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 .vscode/settings.json
 CMN_binViewer-setup64.exe
 CMN_binViewer-setup32.exe
+config.ini

--- a/CMN_binViewer.py
+++ b/CMN_binViewer.py
@@ -969,8 +969,20 @@ class BinViewer(Frame):
         try:
             config_lines = open(config_file, 'r').readlines()
         except:
-            tkMessageBox.showerror("Configuration file " + config_file + " not found! Program files are compromised!")
-            return read_list
+            log.info('creating default config file')
+            self.layout_vertical.set(False)
+            self.fps = IntVar()
+            self.fps.set(fps)
+            self.externalVideoOn = IntVar()
+            self.externalVideoOn.set(external_video)
+            self.edge_marker = IntVar()
+            self.edge_marker.set(edge_marker)
+            self.external_guidelines = IntVar()
+            self.external_guidelines.set(external_guidelines)
+            self.image_resize_factor = IntVar()
+            self.image_resize_factor.set(image_resize_factor)
+            self.write_config()
+            config_lines = open(config_file, 'r').readlines()
 
         for line in config_lines:
             if line[0] == '#' or line == '':

--- a/README.md
+++ b/README.md
@@ -29,16 +29,17 @@ Run in terminal:
 sudo apt-get update
 sudo apt-get install dpkg-dev build-essential libjpeg-dev libtiff-dev libsdl1.2-dev libgstreamer-plugins-base0.10-dev libnotify-dev freeglut3 freeglut3-dev libwebkitgtk-dev libghc-gtk3-dev libwxgtk3.0-gtk3-dev
 
+Then clone this repository:
+```
+git clone https://github.com/CroatianMeteorNetwork/cmn_binviewer.git
+```
+
 Now create a virtual environment, activate it, and install the libraries:
 ---
 virtualenv -p python3 ~/vBinviewer
 source ~/vBinviewer/bin/activate
+cd cmn_binviewer
 pip -y install -r requirements.txt
-```
-
-Then clone this repository:
-```
-git clone https://github.com/CroatianMeteorNetwork/cmn_binviewer.git
 ```
 
 Finally, enter the code directory activate your virtual environment and run the program:

--- a/config.ini
+++ b/config.ini
@@ -1,9 +1,0 @@
-# Configuration file
-# DO NOT CHANGE VALUES MANUALLY
-
-orientation = 0 # 0 horizontal, 1 vertical
-fps = 25
-image_resize_factor = 2
-external_video = 0
-edge_marker = 1
-external_guidelines = 1


### PR DESCRIPTION
Removing the config file from the repo, and creating a default one at runtime if needed. This ensures the users' config isn't overwritten by any update and doesn't block an update. 