### PR TITLE
Bugfix to "save frames" process

### DIFF
--- a/CMN_binViewer.py
+++ b/CMN_binViewer.py
@@ -70,7 +70,7 @@ from module_confirmationClass import Confirmation
 from module_highlightMeteorPath import highlightMeteorPath
 from module_CAMS2CMN import convert_rmsftp_to_cams
 
-version = 3.33
+version = 3.34
 
 # set to true to disable the video radiobutton
 disable_UI_video = False

--- a/CMN_binViewer_setup.iss
+++ b/CMN_binViewer_setup.iss
@@ -7,7 +7,7 @@
 
 [Setup]
 AppName=CMN_binViewer
-AppVersion=3.33
+AppVersion=3.34
 AppPublisher=Croatian Meteor Network
 AppPublisherURL=http://cmn.rgn.hr/
 DefaultDirName={commonpf64}\CMN_binViewer

--- a/CMN_binViewer_setup_win32.iss
+++ b/CMN_binViewer_setup_win32.iss
@@ -7,7 +7,7 @@
 
 [Setup]
 AppName=CMN_binViewer
-AppVersion=3.33
+AppVersion=3.34
 AppPublisher=Croatian Meteor Network
 AppPublisherURL=http://cmn.rgn.hr/
 DefaultDirName={commonpf}\CMN_binViewer

--- a/FF_bin_suite.py
+++ b/FF_bin_suite.py
@@ -785,7 +785,7 @@ def process_array(img_array, Flat_frame = None, Flat_frame_scalar = None, dark_f
 
 
 
-def get_processed_frames(ff_bin, save_path = '.'+os.sep, data_type=1, Flat_frame=None, Flat_frame_scalar=None, dark_frame=None, start_frame=0, end_frame=255, logsort_export=False, no_background=False):
+def get_processed_frames(ff_bin, save_path = '.', data_type=1, Flat_frame=None, Flat_frame_scalar=None, dark_frame=None, start_frame=0, end_frame=255, logsort_export=False, no_background=False):
     """ Makes calibrated BMPs of a particular detection. Used for fireball processing.
 
     ff_bin: *.bin file (or Skypatrol BMP) name and path
@@ -825,7 +825,7 @@ def get_processed_frames(ff_bin, save_path = '.'+os.sep, data_type=1, Flat_frame
         #else:
         img_name_prefix = ff_bin_name.split('.')[0]+"_frame_"+str(nframe).zfill(4)
 
-        img_path_prefix = save_path+img_name_prefix
+        img_path_prefix = os.path.join(save_path, img_name_prefix)
 
         # CAMS data type
         if (data_type == 1) or (data_type == 3):
@@ -855,7 +855,7 @@ def get_processed_frames(ff_bin, save_path = '.'+os.sep, data_type=1, Flat_frame
 
     # Make stack of frames on Skypatrol data
     if data_type == 2:
-        saveImage(skypatrol_stacked_image, save_path+ff_bin_name+'_stacked.bmp', print_name = False, bmp_24bit = logsort_export)
+        saveImage(skypatrol_stacked_image, os.path.join(save_path, ff_bin_name+'_stacked.bmp'), print_name = False, bmp_24bit = logsort_export)
 
     return image_list
 
@@ -1539,7 +1539,7 @@ def cropDetectionSegments(ffBinRead, segmentList, cropSize = 64):
     #saveImage(colorized_frame, img_name+'_colorized.bmp', print_name = False)
 
 
-    #### REGARDING FLATFIELDING AND LIGHTCURVE MAKING:
+    # REGARDING FLATFIELDING AND LIGHTCURVE MAKING:
 
     #flat_dir = "C:\\Users\\Admin\\Desktop\\PER_GIF_making\\PUA_2014081213-Processed\\"
     #flat_dir = "C:\\Users\\Admin\\Desktop\\PER_GIF_making\\PUA_flat\\"

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 CMN Binviewer Change Log
 ========================
+3.34 
+Nov 2021: save-frames was saving in parent of chosen folder
 
 3.33
 Oct 2021: fix black-button bug on Pi


### PR DESCRIPTION
code was concatenating path and filename which failed if the path didn't end in a / or \. Fixed by using os.path.join()